### PR TITLE
Separation library and executables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
-project(Dataforging)
+project(PetitPoucet)
 
 set(CMAKE_CXX_STANDARD 11)
 
@@ -17,91 +17,11 @@ endif()
 ################################
 option(BUILD_PETITPOUCET_EXECUTABLES "Build executables" ON)
 
-
 ################################
-# Dynamic library of PetitPoucet
+# Library
 ################################
+add_subdirectory(PetitPoucet)
 
-set(SHARED_LIB_NAME petitpoucet)
-
-file(GLOB_RECURSE SOURCES_LIB
-    PetitPoucet.hh
-    PetitPoucet/*.cc)
-
-add_library(${SHARED_LIB_NAME} SHARED ${SOURCES_LIB})
-target_include_directories(${SHARED_LIB_NAME}
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/PetitPoucet)
-###################################
-# 3rd party libraries paths
-###################################
-# RTKLIB
-set(RTKLIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/RTKLIB)
-
-file(GLOB_RECURSE RTKLIB_SOURCES ${RTKLIB_PATH}/src/rtklib.h 
-    ${RTKLIB_PATH}/src/stream.c
-    ${RTKLIB_PATH}/src/streamsvr.c
-    ${RTKLIB_PATH}/src/rtkcmn.c
-    ${RTKLIB_PATH}/src/trace.c
-    ${RTKLIB_PATH}/src/solution.c
-    ${RTKLIB_PATH}/src/sbas.c
-    ${RTKLIB_PATH}/src/geoid.c
-    ${RTKLIB_PATH}/src/rcvraw.c
-    ${RTKLIB_PATH}/src/rcv/novatel.c
-    ${RTKLIB_PATH}/src/rcv/ublox.c
-    ${RTKLIB_PATH}/src/rcv/ss2.c
-    ${RTKLIB_PATH}/src/rcv/crescent.c
-    ${RTKLIB_PATH}/src/rcv/skytraq.c
-    ${RTKLIB_PATH}/src/rcv/javad.c
-    ${RTKLIB_PATH}/src/rcv/nvs.c
-    ${RTKLIB_PATH}/src/rcv/binex.c
-    ${RTKLIB_PATH}/src/rcv/rt17.c
-    ${RTKLIB_PATH}/src/rtcm.c
-    ${RTKLIB_PATH}/src/rtcm2.c
-    ${RTKLIB_PATH}/src/rtcm3.c
-    ${RTKLIB_PATH}/src/rtcm3e.c
-    ${RTKLIB_PATH}/src/preceph.c
-    ${RTKLIB_PATH}/src/rcv/septentrio.c
-    ${RTKLIB_PATH}/src/rcv/swiftnav.c
-    ${RTKLIB_PATH}/src/rcv/unicore.c)
-    
-add_library(rtk STATIC ${RTKLIB_SOURCES})
-target_compile_options(rtk PRIVATE -fPIC)
-target_compile_definitions(rtk PRIVATE ENAGLO ENAGAL ENAQZS ENACMP ENAIRN TRACE NFREQ=3 NEXOBS=3 SVR_REUSEADDR)
-set_property(TARGET rtk PROPERTY C_STANDARD 99)
-target_include_directories(rtk PUBLIC ${RTKLIB_PATH}/src)
-set_target_properties(rtk PROPERTIES LINKER_LANGUAGE C)
-
-# FTXUI
-set(FTXUI_ENABLE_INSTALL OFF CACHE BOOL "Disable FTXUI installation") # Because we don't need FTXUI system-wide
-add_subdirectory(deps/ftxui)
-
-############
-# Executable
-############
-
-if(NOT BUILD_PETITPOUCET_EXECUTABLES)
-    return()
+if(BUILD_PETITPOUCET_EXECUTABLES)
+    add_subdirectory(executables)
 endif()
-set(EXECUTABLE_NAME_1 correction_server)
-set(EXECUTABLE_NAME_2 petitpoucet_executable)
-
-add_executable(${EXECUTABLE_NAME_1}
-            main2.cc)    
-add_executable(${EXECUTABLE_NAME_2}
-            main1.cc)       
-
-target_link_libraries(${EXECUTABLE_NAME_1} ${SHARED_LIB_NAME} rtk pthread ftxui::screen ftxui::dom ftxui::component) #RTKLIB depends on pthread
-target_link_libraries(${EXECUTABLE_NAME_2} ${SHARED_LIB_NAME} rtk pthread ftxui::screen ftxui::dom ftxui::component) #RTKLIB depends on pthread
-
-target_link_libraries(${SHARED_LIB_NAME} rtk ftxui::screen ftxui::dom ftxui::component)
-
-############
-# Testing
-############
-
-enable_testing()
-
-add_custom_target(check
-  COMMAND ctest --output-on-failure
-  DEPENDS ${EXECUTABLE_NAME_1}
-)

--- a/src/PetitPoucet/CMakeLists.txt
+++ b/src/PetitPoucet/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.10)
+project(PetitPoucetLibrary)
+
+###################################
+# 3rd party libraries paths
+###################################
+# RTKLIB
+set(RTKLIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../deps/RTKLIB)
+
+file(GLOB_RECURSE RTKLIB_SOURCES ${RTKLIB_PATH}/src/rtklib.h 
+    ${RTKLIB_PATH}/src/stream.c
+    ${RTKLIB_PATH}/src/streamsvr.c
+    ${RTKLIB_PATH}/src/rtkcmn.c
+    ${RTKLIB_PATH}/src/trace.c
+    ${RTKLIB_PATH}/src/solution.c
+    ${RTKLIB_PATH}/src/sbas.c
+    ${RTKLIB_PATH}/src/geoid.c
+    ${RTKLIB_PATH}/src/rcvraw.c
+    ${RTKLIB_PATH}/src/rcv/novatel.c
+    ${RTKLIB_PATH}/src/rcv/ublox.c
+    ${RTKLIB_PATH}/src/rcv/ss2.c
+    ${RTKLIB_PATH}/src/rcv/crescent.c
+    ${RTKLIB_PATH}/src/rcv/skytraq.c
+    ${RTKLIB_PATH}/src/rcv/javad.c
+    ${RTKLIB_PATH}/src/rcv/nvs.c
+    ${RTKLIB_PATH}/src/rcv/binex.c
+    ${RTKLIB_PATH}/src/rcv/rt17.c
+    ${RTKLIB_PATH}/src/rtcm.c
+    ${RTKLIB_PATH}/src/rtcm2.c
+    ${RTKLIB_PATH}/src/rtcm3.c
+    ${RTKLIB_PATH}/src/rtcm3e.c
+    ${RTKLIB_PATH}/src/preceph.c
+    ${RTKLIB_PATH}/src/rcv/septentrio.c
+    ${RTKLIB_PATH}/src/rcv/swiftnav.c
+    ${RTKLIB_PATH}/src/rcv/unicore.c)
+    
+add_library(rtk STATIC ${RTKLIB_SOURCES})
+target_compile_options(rtk PRIVATE -fPIC)
+target_compile_definitions(rtk PRIVATE ENAGLO ENAGAL ENAQZS ENACMP ENAIRN TRACE NFREQ=3 NEXOBS=3 SVR_REUSEADDR)
+set_property(TARGET rtk PROPERTY C_STANDARD 99)
+target_include_directories(rtk PUBLIC ${RTKLIB_PATH}/src)
+set_target_properties(rtk PROPERTIES LINKER_LANGUAGE C)
+
+# FTXUI
+set(FTXUILIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../deps/ftxui)
+set(FTXUI_ENABLE_INSTALL OFF CACHE BOOL "Disable FTXUI installation") # Because we don't need FTXUI system-wide
+add_subdirectory(${FTXUILIB_PATH} ${CMAKE_CURRENT_BINARY_DIR}/ftxui)
+
+################################
+# Dynamic library of PetitPoucet
+################################
+
+set(SHARED_LIB_NAME petitpoucet)
+
+file(GLOB_RECURSE SOURCES_LIB
+    ${CMAKE_CURRENT_SOURCE_DIR}/../PetitPoucet.hh
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cc)
+
+add_library(${SHARED_LIB_NAME} SHARED ${SOURCES_LIB})
+target_include_directories(${SHARED_LIB_NAME}
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/PetitPoucet)
+target_link_libraries(${SHARED_LIB_NAME} rtk ftxui::screen ftxui::dom ftxui::component)

--- a/src/PetitPoucet/Utils/Utils.hh
+++ b/src/PetitPoucet/Utils/Utils.hh
@@ -6,7 +6,7 @@
 #include <optional>
 
 /**
- * @brief Namespace for utilities.
+ * @brief All conversions functions are stored here.
  */
 namespace petitpoucet::utils::conversions
 {
@@ -25,7 +25,7 @@ namespace petitpoucet::utils::conversions
     void ConvertNMEAToWGS84Degrees(long double &coordinate);
 
     /**
-    @brief converts the raw NMEA  (DDMM.MMMMMM) to degrees, minutes and seconds
+    @brief converts the raw NMEA  (DDMM.MMMMMM) to degrees, minutes and seconds. To be implemented
 
     @param longitude the longitude in DDMM.MMMMMM format
     @param latitude the latitude in DDMM.MMMMMM format
@@ -64,10 +64,13 @@ namespace petitpoucet::utils::conversions
 }
 
 /**
- * @brief Namespace for file manipulation utilities.
+ * @brief the class for file manipulation is stored here.
  */
 namespace petitpoucet::utils::filemanipulation
 {
+    /**
+     * @brief This class stores the method for reading the configuration file. It takes the form of a class to allow for future expansion.
+     */
     class ConfigurationSetup
     {
         // Constructors

--- a/src/executables/CMakeLists.txt
+++ b/src/executables/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10)
+project(PetitPoucetExecutable)
+
+set(SHARED_LIB_NAME petitpoucet)
+
+# Add the executable source files
+set(EXECUTABLE_NAME_1 correction_server)
+set(EXECUTABLE_NAME_2 petitpoucet_executable)
+
+add_executable(${EXECUTABLE_NAME_1}
+            main2.cc)    
+add_executable(${EXECUTABLE_NAME_2}
+            main1.cc)       
+
+target_link_libraries(${EXECUTABLE_NAME_1} ${SHARED_LIB_NAME}) 
+target_link_libraries(${EXECUTABLE_NAME_2} ${SHARED_LIB_NAME})

--- a/src/executables/main1.cc
+++ b/src/executables/main1.cc
@@ -1,0 +1,64 @@
+#include "rtklib.h"
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include "../PetitPoucet.hh"
+#include <chrono>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <signal.h>
+
+void runCorrectionServer()
+    {
+        execl("./correction_server", "./correction_server", NULL);
+        std::cerr << "execl() failed!\n";
+    }
+
+int main(int argc, char **argv)
+{
+    std::string configFileName = "../config.txt";
+    std::string casterName;
+    std::string serialPortName, serialPortNamecopy;
+    std::string readConfigFileMessage = "Do you want to use a config file or define the parameters yourself?";
+    int readConfigFile = petitpoucet::ui::giveChoiceTwoOptions("Read from config file", " Define myself at runtime", readConfigFileMessage);
+
+    if(readConfigFile == 0)
+    {
+        std::shared_ptr<petitpoucet::utils::filemanipulation::ConfigurationSetup> setup = std::make_shared<petitpoucet::utils::filemanipulation::ConfigurationSetup>();
+        setup->ReadConfigFile(configFileName, &casterName, &serialPortName);
+    }
+    else if (readConfigFile == 1)
+    {
+        petitpoucet::ui::configfromUserInput(casterName, serialPortName);
+    }
+
+    std::string messageForInstantaneous = "Do you want to get instantaneous position or position over time?";
+    int overTime = petitpoucet::ui::giveChoiceTwoOptions("Instantaneous", "Over time", messageForInstantaneous);
+
+    petitpoucet::serverinterface::PPServerOptions options;
+    petitpoucet::serverinterface::CoordinateSystem coordinateSystem = petitpoucet::serverinterface::CoordinateSystem::WGSDecimals;
+
+    pid_t pid = fork();
+
+    if(pid < 0) 
+    {
+        std::cerr << "Fork failed!\n";
+    }
+    if(pid == 0)
+    {
+        runCorrectionServer();
+    }
+    else
+    {
+        if(!overTime)
+        {
+            petitpoucet::ui::interfaceForInstantaneousPosition(30, options, casterName, serialPortName, coordinateSystem);
+        }
+        else
+        {
+            petitpoucet::ui::interfaceForPositionOverTime(30, options, casterName, serialPortName, coordinateSystem);
+        }
+        kill(pid, SIGTERM);
+    }
+    return 0;
+}

--- a/src/executables/main2.cc
+++ b/src/executables/main2.cc
@@ -1,0 +1,37 @@
+#include "rtklib.h"
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <memory>
+#include <string>
+#include <typeinfo>
+#include <iomanip>
+
+#include "../PetitPoucet.hh"
+
+#define MAXSTR      3 
+
+int main(int argc, char **argv)
+{
+    std::string configFileName = "../config.txt";
+    std::string casterName;
+    std::string serialPortName;
+
+    // Reading the config file
+    std::shared_ptr<petitpoucet::utils::filemanipulation::ConfigurationSetup> setup = std::make_shared<petitpoucet::utils::filemanipulation::ConfigurationSetup>();
+    setup->ReadConfigFile(configFileName, &casterName, &serialPortName);
+    petitpoucet::serverinterface::PPServerOptions options;
+
+    // Create the server
+    petitpoucet::serverinterface::PPServer correctionServer = petitpoucet::serverinterface::PPServer::SetupCorrectionServer(&casterName, &serialPortName,options);
+    sleepms(300);
+    for (int intrflg=0;!intrflg;) 
+    {
+        int stat[3] = {0}, log_stat[3] = {0}, byte[3] = {0}, bps[3] = {0};
+        std::string stringMessage;
+        correctionServer.GetServerStatus(stat, log_stat, byte, bps, &stringMessage);
+        sleepms(1000);
+    }
+    return 0;
+}


### PR DESCRIPTION
This PR concerns the creation of a main CMakeLists.txt at root, and two CMakeLists.txt for the PetitPoucet library and the executables respectively
 